### PR TITLE
Fix two typos in xsd

### DIFF
--- a/3MF Beam Lattice Extension.md
+++ b/3MF Beam Lattice Extension.md
@@ -12,7 +12,7 @@
 
 
 
-| **Version** | 1.0.3 |
+| **Version** | 1.0.4 |
 | --- | --- |
 | **Status** | Published |
 

--- a/3MF Beam Lattice Extension.md
+++ b/3MF Beam Lattice Extension.md
@@ -256,7 +256,7 @@ See [the 3MF Core Specification glossary](https://github.com/3MFConsortium/spec_
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"targetNamespace="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" elementFormDefault="unqualified" attributeFormDefault="unqualified" blockDefault="#all">
+<xs:schema xmlns="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace" targetNamespace="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" elementFormDefault="unqualified" attributeFormDefault="unqualified" blockDefault="#all">
   <xs:annotation>
     <xs:documentation>
       <![CDATA[
@@ -342,7 +342,7 @@ See [the 3MF Core Specification glossary](https://github.com/3MFConsortium/spec_
     <xs:restriction base="xs:string">
       <xs:enumeration value="none"/>
       <xs:enumeration value="inside"/>
-      <xs:enumeration value="outisde"/>
+      <xs:enumeration value="outside"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="ST_CapMode">


### PR DESCRIPTION
- added missing space between `xmlns:xml="http://www.w3.org/XML/1998/namespace"` and `targetNamespace=...`
- changed  `<xs:enumeration value="outisde"/>` to `<xs:enumeration value="outside"/>`